### PR TITLE
Treat ingest stop on already-closed stream as success

### DIFF
--- a/src/server.go
+++ b/src/server.go
@@ -483,9 +483,9 @@ func (s *Server) HandleIngestStop(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.streams[channelId]; !ok {
-		slog.Error("Ingest: Stop handler called with non-existent channel ID.",
-			"channelId", channelId)
-		w.WriteHeader(http.StatusNotFound)
+		// Stream may have already been cleaned up by the connection state callback
+		slog.Info("Ingest: Stream already stopped.", "channelId", channelId)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 	if err := s.streams[channelId].streamerPeerConnection.Close(); err != nil {

--- a/src/server_test.go
+++ b/src/server_test.go
@@ -123,15 +123,15 @@ func TestHandleIngestStop_MethodNotAllowed(t *testing.T) {
 	}
 }
 
-func TestHandleIngestStop_NotFound(t *testing.T) {
+func TestHandleIngestStop_AlreadyStopped(t *testing.T) {
 	srv := testServer()
 	req := httptest.NewRequest(http.MethodDelete, "/ingest/chan1", nil)
 	req.SetPathValue("channelId", "chan1")
 	w := httptest.NewRecorder()
 	srv.HandleIngestStop(w, req)
 
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
When the streamer disconnects, the connection state callback cleans up the stream before the WHIP DELETE request arrives. Return 200 instead of logging an error and returning 404, since the stream is already properly torn down.