### PR TITLE
Add H264 and AV1 thumbnail generation for stream index page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN go build -trimpath -o /out/app .
 # runtime
 FROM alpine:latest
 WORKDIR /app
+RUN apk add --no-cache ffmpeg
 COPY --from=build /out/app /app/app
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["./app"]

--- a/src/go.mod
+++ b/src/go.mod
@@ -4,6 +4,8 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
+	github.com/pion/interceptor v0.1.44
+	github.com/pion/rtp v1.10.1
 	github.com/pion/webrtc/v4 v4.2.11
 )
 
@@ -12,12 +14,10 @@ require (
 	github.com/pion/datachannel v1.6.0 // indirect
 	github.com/pion/dtls/v3 v3.1.2 // indirect
 	github.com/pion/ice/v4 v4.2.2 // indirect
-	github.com/pion/interceptor v0.1.44 // indirect
 	github.com/pion/logging v0.2.4 // indirect
 	github.com/pion/mdns/v2 v2.1.0 // indirect
 	github.com/pion/randutil v0.1.0 // indirect
 	github.com/pion/rtcp v1.2.16 // indirect
-	github.com/pion/rtp v1.10.1 // indirect
 	github.com/pion/sctp v1.9.4 // indirect
 	github.com/pion/sdp/v3 v3.0.18 // indirect
 	github.com/pion/srtp/v3 v3.0.10 // indirect

--- a/src/main.go
+++ b/src/main.go
@@ -136,6 +136,9 @@ func main() {
 	// Websocket API
 	http.HandleFunc("/ws", srv.HandleWebsocket)
 
+	// Thumbnail images for live streams
+	http.HandleFunc("/thumbnail/{channelId}", srv.HandleThumbnail)
+
 	slog.Info("Starting HTTP server...")
 	http.ListenAndServe(*httpListenAddress, nil)
 }

--- a/src/server.go
+++ b/src/server.go
@@ -28,14 +28,17 @@ type IngestInfo struct {
 }
 
 type Server struct {
-	channels    *ChannelStore
-	notifier    *Notifier
-	webrtcAPI   *webrtc.API
+	channels     *ChannelStore
+	notifier     *Notifier
+	webrtcAPI    *webrtc.API
 	webrtcConfig webrtc.Configuration
 
-	mu             sync.RWMutex
-	streams        map[string]*IngestInfo
-	nextViewerId   atomic.Uint64
+	mu           sync.RWMutex
+	streams      map[string]*IngestInfo
+	nextViewerId atomic.Uint64
+
+	thumbnailsMu sync.RWMutex
+	thumbnails   map[string][]byte
 
 	indexTemplate *template.Template
 	watchTemplate *template.Template
@@ -57,6 +60,7 @@ func NewServer(
 		webrtcAPI:     webrtcAPI,
 		webrtcConfig:  webrtcConfig,
 		streams:       map[string]*IngestInfo{},
+		thumbnails:    map[string][]byte{},
 		indexTemplate: indexTemplate,
 		watchTemplate: watchTemplate,
 		upgrader: websocket.Upgrader{
@@ -125,20 +129,29 @@ func (s *Server) HandleIndex(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type ChannelData struct {
-		Id     string
-		IsLive bool
-		Name   string
+		Id           string
+		IsLive       bool
+		HasThumbnail bool
+		Name         string
 	}
 	allChannels := s.channels.All()
 	data := make([]ChannelData, len(allChannels))
+
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	for i, c := range allChannels {
 		_, isLive := s.streams[c.Id]
 		data[i].Id = c.Id
 		data[i].IsLive = isLive
 		data[i].Name = c.Name
 	}
+	s.mu.Unlock()
+
+	s.thumbnailsMu.RLock()
+	for i, c := range allChannels {
+		_, data[i].HasThumbnail = s.thumbnails[c.Id]
+	}
+	s.thumbnailsMu.RUnlock()
+
 	s.indexTemplate.Execute(w, data)
 }
 
@@ -241,13 +254,21 @@ func (s *Server) HandleIngestStart(w http.ResponseWriter, r *http.Request) {
 			slog.Error("Ingest: Could not create local track", "error", err)
 			return
 		}
+		var extractor *thumbnailExtractor
+		if t.Kind() == webrtc.RTPCodecTypeVideo {
+			extractor = newThumbnailExtractor(t.Codec().MimeType)
+		}
 		buf := make([]byte, 1500)
 		for {
 			i, _, err := t.Read(buf)
 			if err != nil {
 				return
 			}
-
+			if extractor != nil {
+				if jpeg := extractor.Feed(buf[:i]); jpeg != nil {
+					s.storeThumbnail(channelInfo.Id, jpeg)
+				}
+			}
 			if _, err = trackLocal.Write(buf[:i]); err != nil {
 				return
 			}
@@ -503,20 +524,41 @@ func (s *Server) onIngestPeerConnectionClosed(channelId string) {
 		slog.Error("Ingest: Channel with unknown ID reported closed", "channelId", channelId)
 		return
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
-	// Close all viewer connections
+	s.mu.Lock()
 	slog.Info("Ingest: Closing viewer connections", "channelId", channelId,
 		"numViewerConnections", len(s.streams[channelId].viewerPeerConnections))
 	for _, c := range s.streams[channelId].viewerPeerConnections {
 		c.Close()
 	}
-
 	delete(s.streams, channelId)
+	s.mu.Unlock()
 
-	// Send websocket notification
+	s.thumbnailsMu.Lock()
+	delete(s.thumbnails, channelId)
+	s.thumbnailsMu.Unlock()
+
 	s.notifier.Broadcast(ChannelNotification{Id: channelId, Name: channelInfo.Name, IsLive: false})
+}
+
+func (s *Server) storeThumbnail(channelId string, data []byte) {
+	s.thumbnailsMu.Lock()
+	s.thumbnails[channelId] = data
+	s.thumbnailsMu.Unlock()
+}
+
+func (s *Server) HandleThumbnail(w http.ResponseWriter, r *http.Request) {
+	channelId := r.PathValue("channelId")
+	s.thumbnailsMu.RLock()
+	data, ok := s.thumbnails[channelId]
+	s.thumbnailsMu.RUnlock()
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "image/jpeg")
+	w.Header().Set("Cache-Control", "no-cache, no-store")
+	w.Write(data)
 }
 
 func (s *Server) addIngestTrack(channelId string, t *webrtc.TrackRemote) (*webrtc.TrackLocalStaticRTP, error) {

--- a/src/thumbnail.go
+++ b/src/thumbnail.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
+	av1frame "github.com/pion/rtp/codecs/av1/frame"
+	"github.com/pion/rtp/codecs/av1/obu"
+)
+
+const thumbnailInterval = 10 * time.Second
+
+var h264StartCode = []byte{0, 0, 0, 1}
+
+// thumbnailExtractor processes an RTP video stream and periodically generates
+// JPEG thumbnails by running FFmpeg on extracted keyframes. Not safe for
+// concurrent use.
+type thumbnailExtractor struct {
+	mimeType string
+	lastGen  time.Time
+
+	// H264 state
+	h264SPS []byte // most recently seen SPS NAL unit
+	h264PPS []byte // most recently seen PPS NAL unit
+	h264FU  []byte // FU-A reassembly buffer
+
+	// AV1 state
+	av1Asm      av1frame.AV1 // OBU element reassembler (handles Z/Y fragmentation)
+	av1Buf      bytes.Buffer
+	av1InSeq    bool   // true while accumulating a coded video sequence
+	av1HasSH    bool   // current accumulation contains a Sequence Header OBU
+	av1HasFrame bool   // current accumulation contains frame data
+	av1SH       []byte // cached Sequence Header OBU to prepend when SH is absent
+}
+
+func newThumbnailExtractor(mimeType string) *thumbnailExtractor {
+	return &thumbnailExtractor{mimeType: strings.ToLower(mimeType)}
+}
+
+// Feed processes one raw RTP packet (header + payload) and returns JPEG bytes
+// when a new thumbnail has been generated, or nil otherwise.
+func (e *thumbnailExtractor) Feed(rawRTP []byte) []byte {
+	if time.Since(e.lastGen) < thumbnailInterval {
+		return nil
+	}
+	var pkt rtp.Packet
+	if err := pkt.Unmarshal(rawRTP); err != nil {
+		return nil
+	}
+	switch e.mimeType {
+	case "video/h264":
+		return e.feedH264(&pkt)
+	case "video/av1":
+		return e.feedAV1(&pkt)
+	}
+	return nil
+}
+
+// feedH264 depacketizes one H264 RTP packet and generates a thumbnail when a
+// complete IDR frame is available.
+func (e *thumbnailExtractor) feedH264(pkt *rtp.Packet) []byte {
+	payload := pkt.Payload
+	if len(payload) == 0 {
+		return nil
+	}
+	naluType := payload[0] & 0x1f
+	switch {
+	case naluType >= 1 && naluType <= 23:
+		// Single NAL unit packet
+		return e.processH264NAL(payload)
+
+	case naluType == 24:
+		// STAP-A: multiple NAL units bundled in one packet
+		off := 1
+		for off+2 <= len(payload) {
+			size := int(payload[off])<<8 | int(payload[off+1])
+			off += 2
+			if off+size > len(payload) {
+				break
+			}
+			if jpeg := e.processH264NAL(payload[off : off+size]); jpeg != nil {
+				return jpeg
+			}
+			off += size
+		}
+
+	case naluType == 28:
+		// FU-A: NAL unit fragmented across multiple packets
+		if len(payload) < 2 {
+			return nil
+		}
+		fuHeader := payload[1]
+		if fuHeader&0x80 != 0 { // start bit
+			// Reconstruct the NAL header from the forbidden_zero_bit+NRI of the
+			// FU indicator and the nal_unit_type from the FU header.
+			e.h264FU = []byte{(payload[0] & 0xe0) | (fuHeader & 0x1f)}
+		}
+		if len(e.h264FU) == 0 {
+			return nil
+		}
+		e.h264FU = append(e.h264FU, payload[2:]...)
+		if fuHeader&0x40 != 0 { // end bit
+			nal := e.h264FU
+			e.h264FU = nil
+			return e.processH264NAL(nal)
+		}
+	}
+	return nil
+}
+
+// processH264NAL inspects a single NAL unit. It caches SPS/PPS and returns
+// JPEG bytes when an IDR frame arrives with both SPS and PPS available.
+func (e *thumbnailExtractor) processH264NAL(nal []byte) []byte {
+	if len(nal) == 0 {
+		return nil
+	}
+	switch nal[0] & 0x1f {
+	case 7: // SPS
+		e.h264SPS = append([]byte(nil), nal...)
+	case 8: // PPS
+		e.h264PPS = append([]byte(nil), nal...)
+	case 5: // IDR (keyframe)
+		if len(e.h264SPS) == 0 || len(e.h264PPS) == 0 {
+			return nil
+		}
+		var frame bytes.Buffer
+		frame.Write(h264StartCode)
+		frame.Write(e.h264SPS)
+		frame.Write(h264StartCode)
+		frame.Write(e.h264PPS)
+		frame.Write(h264StartCode)
+		frame.Write(nal)
+		return e.runFFmpeg("h264", frame.Bytes())
+	}
+	return nil
+}
+
+// feedAV1 depacketizes one AV1 RTP packet and generates a thumbnail once a
+// complete keyframe is available.
+//
+// Uses AV1Packet + frame.AV1 for element-level reassembly (handles Z/Y
+// fragmentation). Each assembled OBU is sanitized before buffering:
+// obu_reserved_1bit is cleared (OBS sets it to 1 which libdav1d rejects) and
+// obu_has_size_field is set to 1 for valid low-overhead bitstream output.
+//
+// The Sequence Header is cached so it can be prepended to keyframes that OBS
+// sends without one (PLI-triggered keyframes sometimes omit the SH).
+func (e *thumbnailExtractor) feedAV1(pkt *rtp.Packet) []byte {
+	var ap codecs.AV1Packet //nolint:staticcheck
+	if _, err := ap.Unmarshal(pkt.Payload); err != nil {
+		return nil
+	}
+	if ap.N {
+		// N=1 marks the start of a new coded video sequence.
+		e.av1Asm = av1frame.AV1{}
+		e.av1Buf.Reset()
+		e.av1InSeq = true
+		e.av1HasSH = false
+		e.av1HasFrame = false
+	}
+	if !e.av1InSeq {
+		return nil
+	}
+	assembled, err := e.av1Asm.ReadFrames(&ap) //nolint:staticcheck
+	if err != nil {
+		return nil
+	}
+	for _, raw := range assembled {
+		e.bufferAV1OBU(raw)
+	}
+	// The RTP marker bit is set on the last packet of each temporal unit.
+	// Only emit once we have actual frame data.
+	if pkt.Marker && e.av1HasFrame {
+		data := make([]byte, e.av1Buf.Len())
+		copy(data, e.av1Buf.Bytes())
+		e.av1Buf.Reset()
+		e.av1InSeq = false
+
+		slog.Info("Thumbnail AV1: emitting to FFmpeg",
+			"hasSH", e.av1HasSH, "cachedSH", len(e.av1SH), "dataLen", len(data))
+
+		if !e.av1HasSH {
+			if len(e.av1SH) == 0 {
+				return nil
+			}
+			var buf bytes.Buffer
+			buf.Write(e.av1SH)
+			buf.Write(data)
+			data = buf.Bytes()
+		}
+		return e.runFFmpeg("av1", data)
+	}
+	return nil
+}
+
+// bufferAV1OBU sanitizes one raw OBU element (as returned by frame.AV1.ReadFrames)
+// and appends it to av1Buf. Ensures obu_has_size_field=1 and clears the reserved
+// bit that OBS's AV1 encoder sets to 1 (violating spec; libdav1d hard-fails on it).
+func (e *thumbnailExtractor) bufferAV1OBU(raw []byte) {
+	if len(raw) == 0 {
+		return
+	}
+	hdr, err := obu.ParseOBUHeader(raw)
+	if err != nil {
+		return
+	}
+	if hdr.Type == obu.OBUTemporalDelimiter || hdr.Type == obu.OBUTileList {
+		return
+	}
+
+	// Extract the payload, handling both sized and unsized OBU headers.
+	var payload []byte
+	if hdr.HasSizeField {
+		size, n, err := obu.ReadLeb128(raw[hdr.Size():])
+		if err != nil {
+			return
+		}
+		end := hdr.Size() + int(n) + int(size)
+		if end > len(raw) {
+			return
+		}
+		payload = raw[hdr.Size()+int(n) : end]
+	} else {
+		payload = raw[hdr.Size():]
+	}
+
+	// Rebuild the header: set size field, clear reserved bit.
+	hdr.HasSizeField = true
+	hdr.Reserved1Bit = false
+	headerBytes := hdr.Marshal()
+	sizeBytes := obu.WriteToLeb128(uint(len(payload)))
+
+	switch hdr.Type {
+	case obu.OBUSequenceHeader:
+		e.av1HasSH = true
+		sh := make([]byte, 0, len(headerBytes)+len(sizeBytes)+len(payload))
+		sh = append(sh, headerBytes...)
+		sh = append(sh, sizeBytes...)
+		sh = append(sh, payload...)
+		e.av1SH = sh
+	case obu.OBUFrame, obu.OBUFrameHeader, obu.OBUTileGroup:
+		e.av1HasFrame = true
+	}
+
+	e.av1Buf.Write(headerBytes)
+	e.av1Buf.Write(sizeBytes)
+	e.av1Buf.Write(payload)
+}
+
+// buildIVF wraps raw AV1 OBU data (one temporal unit) in an IVF container.
+// FFmpeg's ivf demuxer is reliable with AV1 whereas the raw av1 demuxer can
+// fail to locate the Sequence Header when the bitstream has no Annex B framing.
+func buildIVF(data []byte) []byte {
+	buf := make([]byte, 32+12+len(data))
+	// File header (32 bytes)
+	copy(buf[0:], "DKIF")
+	binary.LittleEndian.PutUint16(buf[4:], 0)       // version
+	binary.LittleEndian.PutUint16(buf[6:], 32)      // header length
+	copy(buf[8:], "AV01")                            // codec FourCC
+	binary.LittleEndian.PutUint16(buf[12:], 0)      // width (FFmpeg reads from SH)
+	binary.LittleEndian.PutUint16(buf[14:], 0)      // height
+	binary.LittleEndian.PutUint32(buf[16:], 1)      // timebase numerator
+	binary.LittleEndian.PutUint32(buf[20:], 1)      // timebase denominator
+	binary.LittleEndian.PutUint32(buf[24:], 1)      // total frames
+	binary.LittleEndian.PutUint32(buf[28:], 0)      // unused
+	// Frame header (12 bytes)
+	binary.LittleEndian.PutUint32(buf[32:], uint32(len(data)))
+	binary.LittleEndian.PutUint64(buf[36:], 0) // pts
+	// Frame data
+	copy(buf[44:], data)
+	return buf
+}
+
+func (e *thumbnailExtractor) runFFmpeg(codec string, data []byte) []byte {
+	// AV1: wrap OBU data in an IVF container so FFmpeg's ivf demuxer is used
+	// instead of the raw av1 demuxer (which expects Annex B framing). IVF is
+	// fully sequential so piped input works without seeking.
+	inputFormat := codec
+	if codec == "av1" {
+		inputFormat = "ivf"
+		data = buildIVF(data)
+	}
+
+	cmd := exec.Command("ffmpeg",
+		"-hide_banner", "-loglevel", "error",
+		"-f", inputFormat,
+		"-i", "pipe:0",
+		"-frames:v", "1",
+		"-f", "image2",
+		"-vcodec", "mjpeg",
+		"-q:v", "5",
+		"pipe:1",
+	)
+	cmd.Stdin = bytes.NewReader(data)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		slog.Error("Thumbnail: FFmpeg failed", "codec", codec, "error", err,
+			"ffmpeg_stderr", stderr.String())
+		return nil
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	slog.Info("Thumbnail: Generated", "codec", codec, "bytes", len(out))
+	e.lastGen = time.Now()
+	return out
+}

--- a/src/wwwroot/index.html.tmpl
+++ b/src/wwwroot/index.html.tmpl
@@ -12,9 +12,13 @@
         class="{{if $channel.IsLive}}live{{else}}offline{{end}}"
         style="--animation-order: {{$index}};">
         <a href="/watch/{{$channel.Id}}">
+          {{if and $channel.IsLive $channel.HasThumbnail}}
+          <img class="preview" src="/thumbnail/{{$channel.Id}}" alt="Stream preview">
+          {{else}}
           <div class="preview placeholder">
             <span>{{if $channel.IsLive}}...{{else}}OFFLINE{{end}}</span>
           </div>
+          {{end}}
           <div class="channel-name">{{$channel.Name}}</div>
         </a>
       </li>

--- a/src/wwwroot/style.css
+++ b/src/wwwroot/style.css
@@ -108,6 +108,10 @@ ul.stream-list {
             margin-bottom: 4px;
         }
 
+        ul.stream-list > li img.preview {
+            object-fit: cover;
+        }
+
         ul.stream-list > li div.preview.placeholder {
             display: flex;
             align-items: center;


### PR DESCRIPTION
Extracts keyframes from live RTP video streams and converts them to JPEG thumbnails via FFmpeg, displayed on the stream index page instead of placeholder text.

H264: depacketizes Single NAL / STAP-A / FU-A, assembles SPS+PPS+IDR in Annex B, passes to FFmpeg as raw h264.

AV1: uses AV1Packet + frame.AV1 for element-level reassembly, sanitises each OBU before buffering (clears obu_reserved_1bit which OBS sets to 1 and libdav1d hard-fails on; ensures obu_has_size_field=1). Wraps the accumulated OBU data in an IVF container for reliable FFmpeg decoding. Caches the Sequence Header so PLI-triggered keyframes that omit it can still be decoded.

Thumbnails are served at /thumbnail/{channelId} and refreshed every 10s.